### PR TITLE
added handling for dimsize of t

### DIFF
--- a/common/functions.py
+++ b/common/functions.py
@@ -23,6 +23,8 @@ def softmax(x):
 
 
 def cross_entropy_error(y, t):
+    if t.ndim == 2:
+        t = t.reshape(t.size)
     if y.ndim == 1:
         t = t.reshape(1, t.size)
         y = y.reshape(1, y.size)

--- a/common/functions.py
+++ b/common/functions.py
@@ -23,7 +23,7 @@ def softmax(x):
 
 
 def cross_entropy_error(y, t):
-    if t.ndim == 2:
+    if t.ndim == 2 and t[0].size == 1:
         t = t.reshape(t.size)
     if y.ndim == 1:
         t = t.reshape(1, t.size)


### PR DESCRIPTION
old code have ignored the case such as below:

```
y = array([0.88, 0.22, 0.99])
t = array([[1], [0], [1]])
```

in such case, old `cross_entropy_error` function cannot calculate correctly, because cannot get accurate argmax of t.